### PR TITLE
Add support to register clusters with auto-generated clusterId in CSI 3.0

### DIFF
--- a/deploy/basic-auth/deploy-template.yaml
+++ b/deploy/basic-auth/deploy-template.yaml
@@ -379,7 +379,7 @@ spec:
             - name: swagger-api
               mountPath: /api
         - name: cns-manager
-          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.1.0
+          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.1.1-rc.1
           resources:
             requests:
               cpu: 500m

--- a/deploy/oauth2/deploy-template.yaml
+++ b/deploy/oauth2/deploy-template.yaml
@@ -415,7 +415,7 @@ spec:
             - name: swagger-api
               mountPath: /api
         - name: cns-manager
-          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.1.0
+          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.1.1-rc.1
           resources:
             requests:
               cpu: 500m

--- a/scripts/get-kubeconfig.sh
+++ b/scripts/get-kubeconfig.sh
@@ -172,7 +172,7 @@ rules:
   resources: ["nodes"]
   verbs: ["get", "list"]
 - apiGroups: [""]
-  resources: ["secrets"]
+  resources: ["secrets","configmaps"]
   verbs: ["get", "list"]
 - apiGroups: ["cns.vmware.com"]
   resources: ["cnsvspherevolumemigrations"]


### PR DESCRIPTION
[vSphere CSI driver 3.0.0 ](https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v3.0.0) has an optional feature to auto-generate CSI cluster id if not provided in `vsphere-config-secret`. For cluster registration, CNS manager was relying on this secret for the cluster id to be present.  
We're adding this handling now and it will be released in `v0.1.1` patch.