### PR TITLE
Add orphan volume endpoints

### DIFF
--- a/client-sdk/go/client/api_datastore_operations.go
+++ b/client-sdk/go/client/api_datastore_operations.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,10 +34,11 @@ type DatastoreOperationsApiService service
 
 /*
 DatastoreOperationsApiService Get volumes(CNS &amp; non-CNS) and virtual machines on a datastore.
-This API returns all the volumes(container volumes and non-CNS) as well as the virtual machines on a particular datastore. It is particularly useful to get this information while decommissioning a datastore. The fcd ids outputted from this API can then be used as an input parameter in MigrateVolumes API.
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param datacenter Datacenter name where the datastore is located. This input is case-sensitive.
- * @param datastore Name of the datastore on which container volumes need to be queried. This input is case-sensitive.
+This API returns all the volumes(container volumes and non-CNS) as well as the virtual machines on a particular datastore. It is particularly useful to get this information while decommissioning a datastore.  The fcd ids outputted from this API can then be used as an input parameter in MigrateVolumes API.
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param datacenter Datacenter name where the datastore is located. This input is case-sensitive.
+  - @param datastore Name of the datastore on which container volumes need to be queried. This input is case-sensitive.
+
 @return DatastoreResourcesResult
 */
 func (a *DatastoreOperationsApiService) GetDatastoreResources(ctx context.Context, datacenter string, datastore string) (DatastoreResourcesResult, *http.Response, error) {
@@ -132,7 +133,7 @@ func (a *DatastoreOperationsApiService) GetDatastoreResources(ctx context.Contex
 
 /*
 DatastoreOperationsApiService Migrate volumes from source datastore to target datastore.
-Volumes may need to be moved between the different datastores due to various reasons like retiring older datastores, replacing or disruptive upgrades to existing datastores, saving volumes from failing datastores and so on. This API supports storage vMotion for PVs between different datastores (of same or different types). It returns a job id, the status of which can be retrieved using &#x60;jobStatus&#x60; API.
+Volumes may need to be moved between the different datastores due to various  reasons like retiring older datastores, replacing or disruptive upgrades to existing datastores, saving volumes from failing datastores and so on. This API supports storage vMotion for PVs between different datastores (of same or different types). It returns a job id, the status of which can be retrieved using &#x60;jobStatus&#x60; API.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param datacenter Datacenter name where source and target datastores are located.
  * @param targetDatastore Name of the target datastore.
@@ -140,13 +141,15 @@ Volumes may need to be moved between the different datastores due to various rea
      * @param "SourceDatastore" (optional.String) -  (Optional) Name of the source datastore. Specify only if all volumes from source datastore need to be migrated to destination datastore, and don&#x27;t specify fcd Ids in that case. If specific list of fcd Ids is provided, then source datastore field will be ignored.
      * @param "FcdIdsToMigrate" (optional.Interface of []string) -  (Optional) Array of FCD ids to migrate. If not specified, all volumes from source datastore will be migrated to destination datastore.
      * @param "SkipPolicyCheck" (optional.Bool) -  (Optional) A flag to skip validation of volume policy with target datastore. Set to \&quot;true\&quot; to skip the policy check and force migrate a volume.
+     * @param "SkipVolumeAccessibilityCheck" (optional.Bool) -  (Optional) If this flag is set to &#x27;true&#x27;, it will force migrate the volumes without checking if they will be accessible on target datastore from all cluster nodes(or topology-matching nodes in a topology-aware environment). This may affect the application availability if it gets scheduled on a cluster node that can&#x27;t access the target datastore. So it&#x27;s NOT recommended to set this flag to true.
 @return MigrateVolumesResult
 */
 
 type DatastoreOperationsApiMigrateVolumesOpts struct {
-	SourceDatastore optional.String
-	FcdIdsToMigrate optional.Interface
-	SkipPolicyCheck optional.Bool
+	SourceDatastore              optional.String
+	FcdIdsToMigrate              optional.Interface
+	SkipPolicyCheck              optional.Bool
+	SkipVolumeAccessibilityCheck optional.Bool
 }
 
 func (a *DatastoreOperationsApiService) MigrateVolumes(ctx context.Context, datacenter string, targetDatastore string, localVarOptionals *DatastoreOperationsApiMigrateVolumesOpts) (MigrateVolumesResult, *http.Response, error) {
@@ -175,6 +178,9 @@ func (a *DatastoreOperationsApiService) MigrateVolumes(ctx context.Context, data
 	}
 	if localVarOptionals != nil && localVarOptionals.SkipPolicyCheck.IsSet() {
 		localVarQueryParams.Add("skipPolicyCheck", parameterToString(localVarOptionals.SkipPolicyCheck.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.SkipVolumeAccessibilityCheck.IsSet() {
+		localVarQueryParams.Add("skipVolumeAccessibilityCheck", parameterToString(localVarOptionals.SkipVolumeAccessibilityCheck.Value(), ""))
 	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{}
@@ -251,9 +257,10 @@ func (a *DatastoreOperationsApiService) MigrateVolumes(ctx context.Context, data
 /*
 DatastoreOperationsApiService Resume Create Volume operation on datastore.
 This API will unblock creation of new File and Block volumes on the specified datastore. To block volume provisioning, invoke SuspendVolumeProvisioning API.
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param datacenter Datacenter name where the datastore is located. This input is case-sensitive.
- * @param datastore Name of the datastore where creation of new volumes has to be resumed. This input is case-sensitive.
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param datacenter Datacenter name where the datastore is located. This input is case-sensitive.
+  - @param datastore Name of the datastore where creation of new volumes has to be resumed. This input is case-sensitive.
+
 @return ResumeVolumeProvisioningResult
 */
 func (a *DatastoreOperationsApiService) ResumeVolumeProvisioning(ctx context.Context, datacenter string, datastore string) (ResumeVolumeProvisioningResult, *http.Response, error) {
@@ -349,9 +356,10 @@ func (a *DatastoreOperationsApiService) ResumeVolumeProvisioning(ctx context.Con
 /*
 DatastoreOperationsApiService Suspend Create Volume operation on datastore.
 This API will block creation of new File and Block volumes on the specified datastore. To unblock volume provisioning, invoke ResumeVolumeProvisioning API.  Other volume operations like attach, detach, delete etc. will not get affected for existing volumes.
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param datacenter Datacenter name where the datastore is located. This input is case-sensitive.
- * @param datastore Name of the datastore where creation of new volumes has to be blocked. This input is case-sensitive.
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param datacenter Datacenter name where the datastore is located. This input is case-sensitive.
+  - @param datastore Name of the datastore where creation of new volumes has to be blocked. This input is case-sensitive.
+
 @return SuspendVolumeProvisioningResult
 */
 func (a *DatastoreOperationsApiService) SuspendVolumeProvisioning(ctx context.Context, datacenter string, datastore string) (SuspendVolumeProvisioningResult, *http.Response, error) {

--- a/client-sdk/go/client/api_job_details.go
+++ b/client-sdk/go/client/api_job_details.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,9 +32,10 @@ type JobDetailsApiService service
 
 /*
 JobDetailsApiService Get status of an asynchronous job.
-There are a few functionalities offered through this tool that are long-running and may be running in background. This API helps to fetch the status of a job that&#x27;s submitted, in progress or completed. A job can be in one of the following status:  Queued - Job has been created but hasn&#x27;t started processing.  Running - Job is currently executing.  Success - Job has completed successfully with all tasks succeeding.  Error - Job ran but some or all of its tasks failed.
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param jobId Job Id for which the details need to be fetched.
+There are a few functionalities offered through this tool that are long-running and may be  running in background. This API helps to fetch the status of a job that&#x27;s submitted, in progress or completed. A job can be in one of the following status:  Queued - Job has been created but hasn&#x27;t started processing.  Running - Job is currently executing.  Success - Job has completed successfully with all tasks succeeding.  Error - Job ran but some or all of its tasks failed.
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param jobId Job Id for which the details need to be fetched.
+
 @return JobResult
 */
 func (a *JobDetailsApiService) GetJobStatus(ctx context.Context, jobId string) (JobResult, *http.Response, error) {
@@ -100,7 +101,7 @@ func (a *JobDetailsApiService) GetJobStatus(ctx context.Context, jobId string) (
 			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-		if localVarHttpResponse.StatusCode == 202 {
+		if localVarHttpResponse.StatusCode == 200 {
 			var v JobResult
 			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 			if err != nil {
@@ -129,8 +130,9 @@ func (a *JobDetailsApiService) GetJobStatus(ctx context.Context, jobId string) (
 /*
 JobDetailsApiService Wait until a job is successful or failed.
 This is a blocking API that waits for job to get successful or  fail. Unlike &#x60;getJobStatus&#x60; API which fetches the current status of the job, this will wait for the job to finish before  returning the job result response.
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param jobId Job Id for which to wait to complete.
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param jobId Job Id for which to wait to complete.
+
 @return JobResult
 */
 func (a *JobDetailsApiService) WaitForJob(ctx context.Context, jobId string) (JobResult, *http.Response, error) {
@@ -198,16 +200,6 @@ func (a *JobDetailsApiService) WaitForJob(ctx context.Context, jobId string) (Jo
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v JobResult
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
-		if localVarHttpResponse.StatusCode == 0 {
-			var v ModelError
 			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()

--- a/client-sdk/go/client/api_orphan_volume.go
+++ b/client-sdk/go/client/api_orphan_volume.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2023 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package swagger
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/antihax/optional"
+)
+
+// Linger please
+var (
+	_ context.Context
+)
+
+type OrphanVolumeApiService service
+
+/*
+OrphanVolumeApiService Delete orphan volumes.
+Delete the orphan volumes for the given criteria.
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param deleteAttachedOrphans Set to &#x60;true&#x60; to delete attached orphans. When set to &#x60;true&#x60;, the API will detach the orphan volume from the VM before deleting it.
+ * @param optional nil or *OrphanVolumeApiOrphanVolumeDeleteOpts - Optional Parameters:
+     * @param "Datacenter" (optional.String) -  (Optional) Datacenter name to narrow down the deletion of orphan.
+     * @param "Datastores" (optional.String) -  (Optional) List of comma-separated datastores to narrow down the deletion of orphan volumes to. Specify only if the &#x60;datacenter&#x60; param is specified.
+@return OrphanVolumeDeleteResult
+*/
+
+type OrphanVolumeApiOrphanVolumeDeleteOpts struct {
+	Datacenter optional.String
+	Datastores optional.String
+}
+
+func (a *OrphanVolumeApiService) OrphanVolumeDelete(ctx context.Context, deleteAttachedOrphans bool, localVarOptionals *OrphanVolumeApiOrphanVolumeDeleteOpts) (OrphanVolumeDeleteResult, *http.Response, error) {
+	var (
+		localVarHttpMethod  = strings.ToUpper("Delete")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
+		localVarReturnValue OrphanVolumeDeleteResult
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/orphanvolumes"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	localVarQueryParams.Add("deleteAttachedOrphans", parameterToString(deleteAttachedOrphans, ""))
+	if localVarOptionals != nil && localVarOptionals.Datacenter.IsSet() {
+		localVarQueryParams.Add("datacenter", parameterToString(localVarOptionals.Datacenter.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.Datastores.IsSet() {
+		localVarQueryParams.Add("datastores", parameterToString(localVarOptionals.Datastores.Value(), ""))
+	}
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	if localVarHttpResponse.StatusCode < 300 {
+		// If we succeed, return the data, otherwise pass on to decode error.
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
+			return localVarReturnValue, localVarHttpResponse, err
+		}
+	}
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericSwaggerError{
+			body:  localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		if localVarHttpResponse.StatusCode == 200 {
+			var v OrphanVolumeDeleteResult
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 0 {
+			var v ModelError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		return localVarReturnValue, localVarHttpResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHttpResponse, nil
+}
+
+/*
+OrphanVolumeApiService List all the orphan volumes.
+Orphan volumes are created when the CNS solution creates more than one volume for a Persistent Volume in the Kubernetes cluster. This occurs when the vCenter components are slow, storage is slow, vCenter service restarts, connectivity issues between vCenter and ESXi hosts etc.  Orphan volumes are the volumes that are present in the vSphere datastore but there is no corresponding PersistentVolume in the Kubernetes cluster. This API detects the orphan volumes for the given input parameters and returns a list of orphan volumes.   The orphan volumes could be attached or detached. 1. &#x60;Attached orphan volumes&#x60; - These would have the details set and will have info on the VM it is attached to. 2. &#x60;Detached orphan volumes&#x60; - These are the orphan volumes that do not have the details set.  Orphan volumes are safe to detach since there is no &#x60;PersistentVolume&#x60; in the Kubernetes cluster referring it.
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param includeDetails Set to \&quot;true\&quot; to get a detailed dump of the orphan volume.
+ * @param optional nil or *OrphanVolumeApiOrphanVolumeListOpts - Optional Parameters:
+     * @param "Datacenter" (optional.String) -  (Optional) Datacenter name to narrow down the orphan volume search.
+     * @param "Datastores" (optional.String) -  (Optional) List of comma-separated datastores. Specify only if the &#x60;datacenter&#x60; param is specified.
+@return OrphanVolumeResult
+*/
+
+type OrphanVolumeApiOrphanVolumeListOpts struct {
+	Datacenter optional.String
+	Datastores optional.String
+}
+
+func (a *OrphanVolumeApiService) OrphanVolumeList(ctx context.Context, includeDetails bool, localVarOptionals *OrphanVolumeApiOrphanVolumeListOpts) (OrphanVolumeResult, *http.Response, error) {
+	var (
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
+		localVarReturnValue OrphanVolumeResult
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/orphanvolumes"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	localVarQueryParams.Add("includeDetails", parameterToString(includeDetails, ""))
+	if localVarOptionals != nil && localVarOptionals.Datacenter.IsSet() {
+		localVarQueryParams.Add("datacenter", parameterToString(localVarOptionals.Datacenter.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.Datastores.IsSet() {
+		localVarQueryParams.Add("datastores", parameterToString(localVarOptionals.Datastores.Value(), ""))
+	}
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	if localVarHttpResponse.StatusCode < 300 {
+		// If we succeed, return the data, otherwise pass on to decode error.
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
+			return localVarReturnValue, localVarHttpResponse, err
+		}
+	}
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericSwaggerError{
+			body:  localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		if localVarHttpResponse.StatusCode == 200 {
+			var v OrphanVolumeResult
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 0 {
+			var v ModelError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		return localVarReturnValue, localVarHttpResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHttpResponse, nil
+}

--- a/client-sdk/go/client/api_orphan_volume.go
+++ b/client-sdk/go/client/api_orphan_volume.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 VMware, Inc.
+Copyright 2022 VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,9 +37,9 @@ type OrphanVolumeApiService service
 OrphanVolumeApiService Delete orphan volumes.
 Delete the orphan volumes for the given criteria.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param deleteAttachedOrphans Set to &#x60;true&#x60; to delete attached orphans. When set to &#x60;true&#x60;, the API will detach the orphan volume from the VM before deleting it.
+ * @param deleteAttachedOrphans Set to &#x60;true&#x60; to delete attached orphans. When set to &#x60;true&#x60;,   the API will detach the orphan volume from the VM before deleting it.
  * @param optional nil or *OrphanVolumeApiOrphanVolumeDeleteOpts - Optional Parameters:
-     * @param "Datacenter" (optional.String) -  (Optional) Datacenter name to narrow down the deletion of orphan.
+     * @param "Datacenter" (optional.String) -  (Optional) Datacenter name to narrow down the deletion of orphan volumes to.
      * @param "Datastores" (optional.String) -  (Optional) List of comma-separated datastores to narrow down the deletion of orphan volumes to. Specify only if the &#x60;datacenter&#x60; param is specified.
 @return OrphanVolumeDeleteResult
 */
@@ -146,7 +146,7 @@ func (a *OrphanVolumeApiService) OrphanVolumeDelete(ctx context.Context, deleteA
 
 /*
 OrphanVolumeApiService List all the orphan volumes.
-Orphan volumes are created when the CNS solution creates more than one volume for a Persistent Volume in the Kubernetes cluster. This occurs when the vCenter components are slow, storage is slow, vCenter service restarts, connectivity issues between vCenter and ESXi hosts etc.  Orphan volumes are the volumes that are present in the vSphere datastore but there is no corresponding PersistentVolume in the Kubernetes cluster. This API detects the orphan volumes for the given input parameters and returns a list of orphan volumes.   The orphan volumes could be attached or detached. 1. &#x60;Attached orphan volumes&#x60; - These would have the details set and will have info on the VM it is attached to. 2. &#x60;Detached orphan volumes&#x60; - These are the orphan volumes that do not have the details set.  Orphan volumes are safe to detach since there is no &#x60;PersistentVolume&#x60; in the Kubernetes cluster referring it.
+Returns a list of orphan volumes for the given input parameters, which could be attached or detached.  Since the detection of orphan volumes is an expensive operation, the operation is performed asynchronously at regular intervals.  This API returns the list of orphan volumes found in the last run of the operation.      The response body contains the following fields:  1. &#x60;TotalOrphans&#x60; - The total number of orphan volumes found.    2. &#x60;OrphanVolumes&#x60; - The list of orphan volumes found.    3. &#x60;RetryAfterMinutes&#x60; - The time in minutes after which the next retry should be attempted to get the updated orphan volume list.    4. &#x60;TotalOrphansAttached&#x60; - The total number of orphan volumes found that are attached to a VM.    5. &#x60;TotalOrphansDetached&#x60; - The total number of orphan volumes found that are detached.      Orphan volumes are safe to delete since there is no PersistentVolume in the Kubernetes cluster referring to them.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param includeDetails Set to \&quot;true\&quot; to get a detailed dump of the orphan volume.
  * @param optional nil or *OrphanVolumeApiOrphanVolumeListOpts - Optional Parameters:

--- a/client-sdk/go/client/client.go
+++ b/client-sdk/go/client/client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -54,6 +54,8 @@ type APIClient struct {
 	DatastoreOperationsApi *DatastoreOperationsApiService
 
 	JobDetailsApi *JobDetailsApiService
+
+	OrphanVolumeApi *OrphanVolumeApiService
 }
 
 type service struct {
@@ -74,6 +76,7 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 	// API Services
 	c.DatastoreOperationsApi = (*DatastoreOperationsApiService)(&c.common)
 	c.JobDetailsApi = (*JobDetailsApiService)(&c.common)
+	c.OrphanVolumeApi = (*OrphanVolumeApiService)(&c.common)
 
 	return c
 }

--- a/client-sdk/go/client/model_deregister_cluster_result.go
+++ b/client-sdk/go/client/model_deregister_cluster_result.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2023 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package swagger
+
+type DeregisterClusterResult struct {
+	// Status to indicate if deregistration was successful.
+	Status string `json:"status,omitempty"`
+	// Indicates the clusterId which got deregistered with CNS Manager.
+	ClusterId string `json:"clusterId,omitempty"`
+}

--- a/client-sdk/go/client/model_orphan_volume.go
+++ b/client-sdk/go/client/model_orphan_volume.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2023 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package swagger
+
+type OrphanVolume struct {
+	// ID of the orphan volume.
+	VolumeId string `json:"volumeId,omitempty"`
+	// Name of the orphan volume.
+	VolumeName string `json:"volumeName,omitempty"`
+	// Datastore where the orphan volume is located.
+	Datastore string `json:"datastore,omitempty"`
+	// Create time of the orphan volume.
+	CreateTime string `json:"createTime,omitempty"`
+	// Capacity of the orphan volume.
+	CapacityInMb int64                `json:"capacityInMb,omitempty"`
+	Details      *OrphanVolumeDetails `json:"details,omitempty"`
+}

--- a/client-sdk/go/client/model_orphan_volume_delete_failure.go
+++ b/client-sdk/go/client/model_orphan_volume_delete_failure.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 VMware, Inc.
+Copyright 2023 VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@ limitations under the License.
 */
 package swagger
 
-type Fault struct {
-	// Error message for the fault.
-	Message string `json:"message,omitempty"`
-	// Type of fault.
-	FaultType string `json:"faultType,omitempty"`
+// OrphanVolumeDeleteFailure is the result of a failed orphan volume deletion.  It contains the ID of the orphan volume and the reason for deletion failure.
+type OrphanVolumeDeleteFailure struct {
+	// ID of the orphan volume whose deletion failed.
+	VolumeId string `json:"volumeId"`
+	// Reason for deletion failure.
+	Reason string `json:"reason"`
 }

--- a/client-sdk/go/client/model_orphan_volume_delete_result.go
+++ b/client-sdk/go/client/model_orphan_volume_delete_result.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package swagger
+
+type OrphanVolumeDeleteResult struct {
+	// Number of orphan volumes detected.
+	TotalOrphansDetected int64 `json:"totalOrphansDetected"`
+	// Number of orphan volumes deleted.
+	TotalOrphansDeleted int64 `json:"totalOrphansDeleted"`
+	// Number of deleted orphan volumes that were detached.
+	TotalDetachedOrphansDeleted int64 `json:"totalDetachedOrphansDeleted"`
+	// Number of deleted orphan volumes that were attached to a VM.
+	TotalAttachedOrphansDeleted int64 `json:"totalAttachedOrphansDeleted"`
+}

--- a/client-sdk/go/client/model_orphan_volume_delete_result.go
+++ b/client-sdk/go/client/model_orphan_volume_delete_result.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 VMware, Inc.
+Copyright 2022 VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ limitations under the License.
 
 package swagger
 
+// OrphanVolumeDeleteResult is the result of deleting orphan volumes.
 type OrphanVolumeDeleteResult struct {
 	// Number of orphan volumes detected.
 	TotalOrphansDetected int64 `json:"totalOrphansDetected"`
@@ -25,4 +26,8 @@ type OrphanVolumeDeleteResult struct {
 	TotalDetachedOrphansDeleted int64 `json:"totalDetachedOrphansDeleted"`
 	// Number of deleted orphan volumes that were attached to a VM.
 	TotalAttachedOrphansDeleted int64 `json:"totalAttachedOrphansDeleted"`
+	// Array of successfully deleted orphan volume IDs.
+	SuccessfulOrphanDeletions []string `json:"successfulOrphanDeletions"`
+	// Array of failed orphan volume deletions with the reason for failure for each orphan volume.
+	FailedOrphanDeletions []OrphanVolumeDeleteFailure `json:"failedOrphanDeletions,omitempty"`
 }

--- a/client-sdk/go/client/model_orphan_volume_details.go
+++ b/client-sdk/go/client/model_orphan_volume_details.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package swagger
+
+type OrphanVolumeDetails struct {
+	// Indicates whether the orphan volume is attached to a VM or not.
+	Attached bool `json:"attached,omitempty"`
+	// The name of VM to which the orphan volume is attached.
+	Vm string `json:"vm,omitempty"`
+}

--- a/client-sdk/go/client/model_orphan_volume_result.go
+++ b/client-sdk/go/client/model_orphan_volume_result.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 VMware, Inc.
+Copyright 2022 VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,9 +18,13 @@ package swagger
 
 type OrphanVolumeResult struct {
 	// The total orphan volumes returned.
-	TotalOrphans int64 `json:"totalOrphans,omitempty"`
+	TotalOrphans int64 `json:"totalOrphans"`
 	// This field is set only if includeDetails is set to true.
 	TotalOrphansAttached int64 `json:"totalOrphansAttached,omitempty"`
+	// This field is set only if includeDetails is set to true.
+	TotalOrphansDetached int64 `json:"totalOrphansDetached,omitempty"`
 	// Array of orphan volumes
-	OrphanVolumes []OrphanVolume `json:"orphanVolumes,omitempty"`
+	OrphanVolumes []OrphanVolume `json:"orphanVolumes"`
+	// The time in minutes after which the next retry should be attempted to get the updated orphan volume list.
+	RetryAfterMinutes int64 `json:"retryAfterMinutes"`
 }

--- a/client-sdk/go/client/model_orphan_volume_result.go
+++ b/client-sdk/go/client/model_orphan_volume_result.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2023 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package swagger
+
+type OrphanVolumeResult struct {
+	// The total orphan volumes returned.
+	TotalOrphans int64 `json:"totalOrphans,omitempty"`
+	// This field is set only if includeDetails is set to true.
+	TotalOrphansAttached int64 `json:"totalOrphansAttached,omitempty"`
+	// Array of orphan volumes
+	OrphanVolumes []OrphanVolume `json:"orphanVolumes,omitempty"`
+}

--- a/client-sdk/go/client/model_register_cluster_result.go
+++ b/client-sdk/go/client/model_register_cluster_result.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2023 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package swagger
+
+type RegisterClusterResult struct {
+	// Status to indicate if registration was successful.
+	Status string `json:"status,omitempty"`
+	// Indicates the clusterId which got registered with CNS Manager.
+	ClusterId string `json:"clusterId,omitempty"`
+}

--- a/client-sdk/go/client/model_registercluster_body.go
+++ b/client-sdk/go/client/model_registercluster_body.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 VMware, Inc.
+Copyright 2023 VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,9 +15,11 @@ limitations under the License.
 */
 package swagger
 
-type Fault struct {
-	// Error message for the fault.
-	Message string `json:"message,omitempty"`
-	// Type of fault.
-	FaultType string `json:"faultType,omitempty"`
+import (
+	"os"
+)
+
+type RegisterclusterBody struct {
+	// A file with cluster kubeconfig content.
+	ClusterKubeConfigFile **os.File `json:"clusterKubeConfigFile"`
 }

--- a/client-sdk/go/examples/basicauth_client.go
+++ b/client-sdk/go/examples/basicauth_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	apiclient "cns.vmware.com/cns-manager/client"
+	"github.com/antihax/optional"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -45,15 +46,15 @@ func main() {
 	//================API Invocation Examples===========
 
 	//======Datastore Resources============
-	datacenter := "VSAN-DC"
-	datastore := "vsanDatastore"
-	res, resp, err := client.DatastoreOperationsApi.GetDatastoreResources(ctx, datacenter, datastore)
-	if err != nil {
-		logger.Error(err, "failed to get datastore resources")
-	}
+	// datacenter := "VSAN-DC"
+	// datastore := "vsanDatastore"
+	// res, resp, err := client.DatastoreOperationsApi.GetDatastoreResources(ctx, datacenter, datastore)
+	// if err != nil {
+	// 	logger.Error(err, "failed to get datastore resources")
+	// }
 
-	logger.Info("Result", "result", res) //This gives the result in json format
-	logger.Info("HTTP status", "status", resp.Status)
+	// logger.Info("Result", "result", res) //This gives the result in json format
+	// logger.Info("HTTP status", "status", resp.Status)
 	//=======================================================
 
 	//====== Migrate Volumes========
@@ -104,6 +105,36 @@ func main() {
 	// res, resp, err := client.DatastoreOperationsApi.ResumeVolumeProvisioning(ctx, datacenter, datastore)
 	// if err != nil {
 	// 	logger.Error(err, "failed to resume provisioing volumes on datastore")
+	// }
+	// logger.Info("Result", "result", res) //This gives the result in json format
+	// logger.Info("HTTP status", "status", resp.Status)
+	//=======================================================
+
+	//======List orphan volumes======
+	includeDetails := true
+	opts := &apiclient.OrphanVolumeApiOrphanVolumeListOpts{
+		Datacenter: optional.NewString("VSAN-DC"),
+		Datastores: optional.NewString("vsanDatastore"),
+	}
+
+	res, resp, err := client.OrphanVolumeApi.OrphanVolumeList(ctx, includeDetails, opts)
+	if err != nil {
+		logger.Error(err, "failed to list orphan volumes")
+	}
+	logger.Info("Result", "result", res) //This gives the result in json format
+	logger.Info("HTTP status", "status", resp.Status)
+	//=======================================================
+
+	//======Delete orphan volumes======
+	// deleteAttachedOrphans := false
+	// opts := &apiclient.OrphanVolumeApiOrphanVolumeDeleteOpts{
+	// 	Datacenter: optional.NewString("VSAN-DC"),
+	// 	Datastores: optional.NewString("vsanDatastore"),
+	// }
+
+	// res, resp, err := client.OrphanVolumeApi.OrphanVolumeDelete(ctx, deleteAttachedOrphans, opts)
+	// if err != nil {
+	// 	logger.Error(err, "failed to delete orphan volumes")
 	// }
 	// logger.Info("Result", "result", res) //This gives the result in json format
 	// logger.Info("HTTP status", "status", resp.Status)

--- a/deploy/basic-auth/deploy-template.yaml
+++ b/deploy/basic-auth/deploy-template.yaml
@@ -239,7 +239,7 @@ status:
   storedVersions: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   creationTimestamp: null
   name: cns-manager
@@ -286,12 +286,12 @@ rules:
       - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: cns-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: cns-manager
 subjects:
   - kind: ServiceAccount
@@ -307,12 +307,13 @@ data:
     { 
       "auth-type": "%AUTH_TYPE%",
       "snapshot_prefix": "snapshot",
-      "auto-delete-ov": "enable",
+      "auto-delete-ov": "disable",
       "cns-manager-namespace": "%CNS_MANAGER_NAMESPACE%",
       "max-volume-migration-job-workers": "10",
       "max-volume-migration-task-workers": "10",
       "volume-migration-job-cleanup-elapse-time-mins": "720",
-      "volume-migration-job-cleanup-interval-mins": "30"
+      "volume-migration-job-cleanup-interval-mins": "30",
+      "vso-create-time-limit-mins": "60"
     }
 ---
 apiVersion: apps/v1
@@ -379,7 +380,7 @@ spec:
             - name: swagger-api
               mountPath: /api
         - name: cns-manager
-          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.1.1-rc.1
+          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.2.0-rc.5
           resources:
             requests:
               cpu: 500m

--- a/deploy/basic-auth/deploy-template.yaml
+++ b/deploy/basic-auth/deploy-template.yaml
@@ -313,7 +313,7 @@ data:
       "max-volume-migration-task-workers": "10",
       "volume-migration-job-cleanup-elapse-time-mins": "720",
       "volume-migration-job-cleanup-interval-mins": "30",
-      "vso-create-time-limit-mins": "60"
+      "orphan-volume-detection-interval-mins": "50"
     }
 ---
 apiVersion: apps/v1
@@ -380,7 +380,7 @@ spec:
             - name: swagger-api
               mountPath: /api
         - name: cns-manager
-          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.2.0-rc.5
+          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.2.0-rc.6
           resources:
             requests:
               cpu: 500m

--- a/deploy/basic-auth/nginx.conf
+++ b/deploy/basic-auth/nginx.conf
@@ -28,5 +28,16 @@ http {
             proxy_set_header       Host $host;
             proxy_buffering        on;
         }
+
+        #Since /waitforjob is supposed to be a blocking API call, set a long timeout of 1d
+        location /1.0.0/waitforjob {
+            proxy_pass             http://localhost:8100;
+            proxy_set_header       Host $host;
+            proxy_buffering        on;
+
+            proxy_read_timeout 1d;
+            proxy_connect_timeout 1d;
+            proxy_send_timeout 1d;
+        }
     }
 }

--- a/deploy/basic-auth/nginx.conf
+++ b/deploy/basic-auth/nginx.conf
@@ -39,5 +39,15 @@ http {
             proxy_connect_timeout 1d;
             proxy_send_timeout 1d;
         }
+
+        # Since DELETE /orphanvolumes could be a long running operation,
+        # set a timeout of 30m for /orphanvolumes endpoints
+        location /1.0.0/orphanvolumes {
+            proxy_pass             http://localhost:8100;
+            proxy_set_header       Host $host;
+            proxy_buffering        on;
+
+            proxy_read_timeout 30m;
+        }
     }
 }

--- a/deploy/oauth2/deploy-template.yaml
+++ b/deploy/oauth2/deploy-template.yaml
@@ -239,7 +239,7 @@ status:
   storedVersions: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   creationTimestamp: null
   name: cns-manager
@@ -286,12 +286,12 @@ rules:
       - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: cns-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: cns-manager
 subjects:
   - kind: ServiceAccount
@@ -308,12 +308,13 @@ data:
       "auth-type": "%AUTH_TYPE%",
       "allowedUsers": ["johndoe@helloabc.com"],
       "snapshot_prefix": "snapshot",
-      "auto-delete-ov": "enable",
+      "auto-delete-ov": "disable",
       "cns-manager-namespace": "%CNS_MANAGER_NAMESPACE%",
       "max-volume-migration-job-workers": "10",
       "max-volume-migration-task-workers": "10",
       "volume-migration-job-cleanup-elapse-time-mins": "720",
-      "volume-migration-job-cleanup-interval-mins": "30"
+      "volume-migration-job-cleanup-interval-mins": "30",
+      "vso-create-time-limit-mins": "60"
     }
 ---
 apiVersion: apps/v1
@@ -415,7 +416,7 @@ spec:
             - name: swagger-api
               mountPath: /api
         - name: cns-manager
-          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.1.1-rc.1
+          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.2.0-rc.5
           resources:
             requests:
               cpu: 500m

--- a/deploy/oauth2/deploy-template.yaml
+++ b/deploy/oauth2/deploy-template.yaml
@@ -314,7 +314,7 @@ data:
       "max-volume-migration-task-workers": "10",
       "volume-migration-job-cleanup-elapse-time-mins": "720",
       "volume-migration-job-cleanup-interval-mins": "30",
-      "vso-create-time-limit-mins": "60"
+      "orphan-volume-detection-interval-mins": "50"
     }
 ---
 apiVersion: apps/v1
@@ -416,7 +416,7 @@ spec:
             - name: swagger-api
               mountPath: /api
         - name: cns-manager
-          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.2.0-rc.5
+          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.2.0-rc.6
           resources:
             requests:
               cpu: 500m

--- a/deploy/oauth2/nginx.conf
+++ b/deploy/oauth2/nginx.conf
@@ -52,6 +52,27 @@ http {
             proxy_buffering        on;
         }
 
+        #Since /waitforjob is supposed to be a blocking API call, set a long timeout of 1d	
+        location /1.0.0/waitforjob {	
+            auth_request /oauth2/auth;	
+            # pass information via X-User and X-Forwarded-Email headers to backend,	
+            # requires running with --set-xauthrequest flag	
+            auth_request_set $user   $upstream_http_x_auth_request_user;	
+            auth_request_set $email  $upstream_http_x_auth_request_email;	
+            proxy_set_header X-User  $user;	
+            proxy_set_header X-Forwarded-Email $email;	
+            # if you enabled --cookie-refresh, this is needed for it to work with auth_request	
+            auth_request_set $auth_cookie $upstream_http_set_cookie;	
+            add_header Set-Cookie $auth_cookie;	
+            	
+            proxy_pass             http://localhost:8100;	
+            proxy_set_header       Host $host;	
+            proxy_buffering        on;	
+            proxy_read_timeout 1d;	
+            proxy_connect_timeout 1d;	
+            proxy_send_timeout 1d;	
+        }
+
         location /oauth2/ {
             proxy_pass       http://127.0.0.1:4180;
             proxy_set_header Host                    $host;

--- a/deploy/oauth2/nginx.conf
+++ b/deploy/oauth2/nginx.conf
@@ -73,6 +73,29 @@ http {
             proxy_send_timeout 1d;	
         }
 
+        # Since DELETE /orphanvolumes could be a long running operation,
+        # set a timeout of 30m for /orphanvolumes endpoints
+        location /1.0.0/orphanvolumes {
+            auth_request /oauth2/auth;
+
+            # pass information via X-User and X-Forwarded-Email headers to backend,
+            # requires running with --set-xauthrequest flag
+            auth_request_set $user   $upstream_http_x_auth_request_user;
+            auth_request_set $email  $upstream_http_x_auth_request_email;
+            proxy_set_header X-User  $user;
+            proxy_set_header X-Forwarded-Email $email;
+
+            # if you enabled --cookie-refresh, this is needed for it to work with auth_request
+            auth_request_set $auth_cookie $upstream_http_set_cookie;
+            add_header Set-Cookie $auth_cookie;
+
+            proxy_pass             http://localhost:8100;
+            proxy_set_header       Host $host;
+            proxy_buffering        on;
+
+            proxy_read_timeout 30m;
+        }
+
         location /oauth2/ {
             proxy_pass       http://127.0.0.1:4180;
             proxy_set_header Host                    $host;

--- a/deploy/swagger-template.yaml
+++ b/deploy/swagger-template.yaml
@@ -72,7 +72,7 @@ paths:
       parameters:
         - name: csiDriverSecretName
           in: query
-          description: (Optional) Refers to the name of the config secret of vsphere-csi-driver.
+          description: Refers to the name of the config secret of vsphere-csi-driver.
           style: form
           explode: true
           schema:
@@ -81,7 +81,7 @@ paths:
             default: vsphere-config-secret
         - name: csiDriverSecretNamespace
           in: query
-          description: (Optional) Refers to the namespace of the config secret of vsphere-csi-driver.
+          description: Refers to the namespace of the config secret of vsphere-csi-driver.
           style: form
           explode: true
           schema:
@@ -818,6 +818,9 @@ components:
       example:
         message: Successfully resumed volume provisioning on datstore nfs0-1.
     OrphanVolumeDetails:
+      type: object
+      description: OrphanVolumeDetails represents if the orphan volume is attached to a VM or not.
+      required: [ attached ]
       properties:
         attached:
           type: boolean

--- a/deploy/swagger-template.yaml
+++ b/deploy/swagger-template.yaml
@@ -19,6 +19,8 @@ tags:
     description: Operations invoked directly on datastores.
   - name: JobDetails
     description: Operations related to CNS manager asynchronous jobs.
+  - name: OrphanVolume	
+    description: Everything about orphan volumes.
 paths:
   /listregisteredclusters:
     get:
@@ -406,6 +408,131 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /orphanvolumes:	
+    get:	
+      tags:	
+      - OrphanVolume	
+      summary: List all the orphan volumes.	
+      description: >-
+        Returns a list of orphan volumes for the given input parameters, which could be attached or detached.	
+        Since the detection of orphan volumes is an expensive operation, the operation is performed asynchronously at regular intervals.	
+        This API returns the list of orphan volumes found in the last run of the operation.	
+        	
+        	
+        The response body contains the following fields:	
+        1. `TotalOrphans` - The total number of orphan volumes found.	
+        	
+        2. `OrphanVolumes` - The list of orphan volumes found.	
+        	
+        3. `RetryAfterMinutes` - The time in minutes after which the next retry should be attempted to get the updated orphan volume list.	
+        	
+        4. `TotalOrphansAttached` - The total number of orphan volumes found that are attached to a VM.	
+        	
+        5. `TotalOrphansDetached` - The total number of orphan volumes found that are detached.	
+        	
+        	
+        Orphan volumes are safe to delete since there is no PersistentVolume in the Kubernetes cluster referring to them.	
+      operationId: orphanVolumeList	
+      parameters:	
+        - name: includeDetails	
+          in: query	
+          description: Set to "true" to get a detailed dump of the orphan volume.	
+          required: true	
+          style: form	
+          explode: true	
+          schema:	
+            type: boolean	
+            format: boolean	
+            default: false	
+        - name: datacenter	
+          in: query	
+          description: (Optional) Datacenter name to narrow down the orphan volume search.	
+          required: false	
+          style: form	
+          explode: true	
+          schema:	
+            type: string	
+            format: string	
+        - name: datastores	
+          in: query	
+          description: (Optional) List of comma-separated datastores. Specify only if	
+            the `datacenter` param is specified.	
+          required: false	
+          style: form	
+          explode: true	
+          schema:	
+            type: string	
+            format: string	
+      responses:	
+        "200":	
+          description: Returns OrphanVolumeResult.	
+          content:	
+            application/json:	
+              schema:	
+                $ref: '#/components/schemas/OrphanVolumeResult'	
+          headers:	
+            X-Retry-After:	
+              description: The number of seconds to wait before retrying the request.	
+              schema:	
+                type: string	
+        default:	
+          description: unexpected error	
+          content:	
+            application/json:	
+              schema:	
+                $ref: '#/components/schemas/Error'	
+    delete:	
+      tags:	
+        - OrphanVolume	
+      summary: Delete orphan volumes.	
+      description: Delete the orphan volumes for the given criteria.	
+      operationId: orphanVolumeDelete	
+      parameters:	
+        - name: deleteAttachedOrphans	
+          in: query	
+          description: >-	
+            Set to `true` to delete attached orphans. When set to `true`, 	
+            the API will detach the orphan volume from the VM before deleting it.	
+          required: true	
+          style: form	
+          explode: true	
+          schema:	
+            type: boolean	
+            format: boolean	
+            default: false	
+        - name: datacenter	
+          in: query	
+          description: (Optional) Datacenter name to narrow down the deletion of orphan volumes to.	
+          required: false	
+          style: form	
+          explode: true	
+          schema:	
+            type: string	
+            format: string	
+        - name: datastores	
+          in: query	
+          description: (Optional) List of comma-separated datastores to narrow down	
+            the deletion of orphan volumes to. Specify only if the `datacenter` param	
+            is specified.	
+          required: false	
+          style: form	
+          explode: true	
+          schema:	
+            type: string	
+            format: string	
+      responses:	
+        "200":	
+          description: Returns OrphanVolumeDeleteResult.	
+          content:	
+            application/json:	
+              schema:	
+                $ref: '#/components/schemas/OrphanVolumeDeleteResult'	
+        default:	
+          description: unexpected error	
+          content:	
+            application/json:	
+              schema:	
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     Error:
@@ -690,3 +817,203 @@ components:
           example: "Successfully resumed volume provisioning on datstore nfs0-1."
       example:
         message: Successfully resumed volume provisioning on datstore nfs0-1.
+    OrphanVolumeDetails:
+      properties:
+        attached:
+          type: boolean
+          description: Indicates whether the orphan volume is attached to a VM or
+            not.
+          example: true
+        vm:
+          type: string
+          description: The name of VM to which the orphan volume is attached.
+          example: k8s-node-1
+      example:
+        vm: k8s-node-1
+        attached: true
+    OrphanVolume:
+      description: >-
+        Orphan volumes are volumes that are present in the vSphere datastore but have
+        no corresponding PersistentVolume in the Kubernetes cluster. 
+        Primarily, Orphan volumes are created when the CNS solution creates more than one volume
+        for a Persistent Volume in the Kubernetes cluster. This can occur when the
+        vCenter components are slow, storage is slow, vCenter service restarts, or
+        there are connectivity issues between vCenter and ESXi hosts
+      properties:
+        volumeId:
+          type: string
+          description: ID of the orphan volume.
+          example: 64d6787e-397b-4c99-a151-c6f37c49fcff
+        volumeName:
+          type: string
+          description: Name of the orphan volume.
+          example: pvc-338934c2-6067-489a-a929-7c559ea18c82
+        datacenter:
+          type: string
+          description: Datacenter where the orphan volume is located.
+          example: VSAN-DC
+        datastore:
+          type: string
+          description: Datastore where the orphan volume is located.
+          example: vsanDatastore
+        createTime:
+          type: string
+          description: Create time of the orphan volume.
+          example: 2021-07-23 19:19:59.365062 +0000 UTC
+        capacityInMb:
+          type: integer
+          description: Capacity of the orphan volume.
+          format: int64
+          example: 100
+        details:
+          $ref: '#/components/schemas/OrphanVolumeDetails'
+      example:
+        createTime: 2021-07-23 19:19:59.365062 +0000 UTC
+        datacenter: VSAN-DC
+        datastore: vsanDatastore
+        volumeName: pvc-338934c2-6067-489a-a929-7c559ea18c82
+        volumeId: 64d6787e-397b-4c99-a151-c6f37c49fcff
+        details:
+          vm: k8s-node-1
+          attached: true
+        capacityInMb: 100
+    OrphanVolumeResult:
+      required:
+        - totalOrphans
+        - orphanVolumes
+        - retryAfterMinutes
+      properties:
+        totalOrphans:
+          type: integer
+          description: The total orphan volumes returned.
+          format: int64
+          example: 1
+        totalOrphansAttached:
+          type: integer
+          description: This field is set only if includeDetails is set to true.
+          format: int64
+          example: 1
+        totalOrphansDetached:
+          type: integer
+          description: This field is set only if includeDetails is set to true.
+          format: int64
+          example: 1
+        orphanVolumes:
+          type: array
+          description: Array of orphan volumes
+          items:
+            $ref: '#/components/schemas/OrphanVolume'
+        retryAfterMinutes:
+          type: integer
+          description: The time in minutes after which the next retry should be
+            attempted to get the updated orphan volume list.
+          format: int64
+          example: 1
+      example:
+        totalOrphansAttached: 2
+        totalOrphansDetached: 1
+        orphanVolumes:
+          - createTime: 2021-07-23 19:19:59.365062 +0000 UTC
+            datacenter: VSAN-DC
+            datastore: vsanDatastore
+            volumeName: pvc-338934c2-6067-489a-a929-7c559ea18c82
+            volumeId: 64d6787e-397b-4c99-a151-c6f37c49fcff
+            details:
+              vm: k8s-node-1
+              attached: true
+            capacityInMb: 100
+          - createTime: 2021-07-23 19:19:59.365062 +0000 UTC
+            datacenter: VSAN-DC
+            datastore: vsanDatastore
+            volumeName: pvc-338934c2-6067-489a-a929-7c559ea18c82
+            volumeId: 64d6787e-397b-4c99-a151-c6f37c49fcff
+            details:
+              vm: k8s-node-1
+              attached: true
+            capacityInMb: 100
+          - createTime: 2021-07-23 19:19:59.365062 +0000 UTC
+            datacenter: VSAN-DC
+            datastore: local-0 (1)
+            volumeName: pvc-338934c2-6067-489a-a929-7c559ea18c82
+            volumeId: 64d6787e-397b-4c99-a151-c6f37c49fcff
+            details:
+              attached: false
+            capacityInMb: 100
+        totalOrphans: 3
+        retryAfter: 10
+    OrphanVolumeDeleteResult:
+      type: object
+      description: OrphanVolumeDeleteResult is the result of deleting orphan volumes.
+      required:
+        - totalOrphansDetected
+        - totalOrphansDeleted
+        - totalDetachedOrphansDeleted
+        - totalAttachedOrphansDeleted
+        - successfulOrphanDeletions
+      properties:
+        totalOrphansDetected:
+          type: integer
+          description: Number of orphan volumes detected.
+          format: int64
+          example: 10
+        totalOrphansDeleted:
+          type: integer
+          description: Number of orphan volumes deleted.
+          format: int64
+          example: 5
+        totalDetachedOrphansDeleted:
+          type: integer
+          description: Number of deleted orphan volumes that were detached.
+          format: int64
+          example: 3
+        totalAttachedOrphansDeleted:
+          type: integer
+          description: Number of deleted orphan volumes that were attached to a VM.
+          format: int64
+          example: 2
+        successfulOrphanDeletions:
+          type: array
+          description: Array of successfully deleted orphan volume IDs.
+          items:
+            type: string
+        failedOrphanDeletions:
+          description: Array of failed orphan volume deletions with the reason for failure for each orphan volume.
+          type: array
+          items:
+            $ref: '#/components/schemas/OrphanVolumeDeleteFailure'
+      example:
+        totalOrphansDetected: 7
+        totalOrphansDeleted: 5
+        totalDetachedOrphansDeleted: 3
+        totalAttachedOrphansDeleted: 2
+        successfulOrphanDeletions:
+          - 44d6787e-697b-4d99-a151-c3f37c49fcff
+          - 54d6787e-397b-4c99-a151-c4f37c49fcff
+          - 74d6787e-397b-4c99-a151-c5f37c49fcff
+          - 84d6787e-397b-4c99-a151-c6f37c49fcff
+          - 94d7787e-397b-4c99-a151-c7f37c49fcff
+        failedOrphanDeletions:
+          - volumeId: 64d6787e-397b-4c99-a151-c6f37c49fcff
+            reason: Failed to delete orphan volume
+          - volumeId: 94d6787e-397b-4c99-a151-c7f37c49fcff
+            reason: Failed to delete orphan volume
+    OrphanVolumeDeleteFailure:
+      type: object
+      description: >-
+        OrphanVolumeDeleteFailure is the result of a failed orphan volume deletion. 
+        It contains the ID of the orphan volume and the reason for deletion failure.
+      required:
+        - volumeId
+        - reason
+      properties:
+        volumeId:
+          type: string
+          description: ID of the orphan volume whose deletion failed.
+          example: 64d6787e-397b-4c99-a151-c6f37c49fcff
+        reason:
+          type: string
+          description: Reason for deletion failure.
+          example: Failed to delete orphan volume
+      example:
+        volumeId: 64d6787e-397b-4c99-a151-c6f37c49fcff
+        reason: Failed to delete orphan volume


### PR DESCRIPTION
This MR adds following:
1. Orphan volume endpoints to Swagger yaml. 
2. Required changes in basicauth/oauth2 deployment manifests
3. Increased timeout for /waitforjob API in nginx conf
4. client-sdk for orphan volume APIs as well as missing models in client-sdk
5. Orphan volume API client examples in `basicauth_client.go`.