### PR TITLE
Increase default nginx timeout to 300s

### DIFF
--- a/deploy/basic-auth/nginx.conf
+++ b/deploy/basic-auth/nginx.conf
@@ -27,6 +27,10 @@ http {
             proxy_pass             http://localhost:8100;
             proxy_set_header       Host $host;
             proxy_buffering        on;
+
+            proxy_read_timeout 300;
+            proxy_connect_timeout 300;
+            proxy_send_timeout 300;
         }
 
         #Since /waitforjob is supposed to be a blocking API call, set a long timeout of 1d

--- a/deploy/oauth2/nginx.conf
+++ b/deploy/oauth2/nginx.conf
@@ -50,6 +50,10 @@ http {
             proxy_pass             http://localhost:8100;
             proxy_set_header       Host $host;
             proxy_buffering        on;
+
+            proxy_read_timeout 300;
+            proxy_connect_timeout 300;
+            proxy_send_timeout 300;
         }
 
         #Since /waitforjob is supposed to be a blocking API call, set a long timeout of 1d	


### PR DESCRIPTION
This MR increases the default nginx timeout for all APIs accessible on path `/1.0.0` to 300s.