### PR TITLE
Changes to update client-sdk files and documentation as per recent changes made for orphan volumes feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Example:
 * Invoke `/registercluster` API on CNS manager by uploading the kubeconfig file. You may also modify other input parameters for the API based on your cluster configuration.
 The API can also be invoked from command line. Here is an example:
 ```
-curl -X 'POST' "http://CNS-MANAGER-ENDPOINT/1.0.0/registercluster?csiDriverSecretName=vsphere-config-secret&csiDriverNamespace=vmware-system-csi" -H 'accept: application/json' -H 'Content-Type: multipart/form-data' -F 'clusterKubeConfigFile=@output_file_name' -u "Admistrator:Admin123@"
+curl -X 'POST' "http://CNS-MANAGER-ENDPOINT/1.0.0/registercluster?csiDriverSecretName=vsphere-config-secret&csiDriverSecretNamespace=vmware-system-csi" -H 'accept: application/json' -H 'Content-Type: multipart/form-data' -F 'clusterKubeConfigFile=@output_file_name' -u "Admistrator:Admin123@"
 ```
 * Once the cluster is registered, you may delete this file from the machine.
 
@@ -61,11 +61,11 @@ curl -X 'POST' "http://CNS-MANAGER-ENDPOINT/1.0.0/registercluster?csiDriverSecre
 See the [upgrade instructions](docs/book/deployment/upgrade.md) if you're upgrading previously deployed cns-manager instance to a newer release.
 ## Functionalities currently offered through cns-manager
 
-* **Storage vMotion for CNS volumes**   
+* **Storage vMotion for CNS volumes**  
 This feature allows migrating volumes from one datastore to another. Read [here](docs/book/features/storage_vmotion.md) for more details about this feature.
 
 * **Orphan volumes detection & deletion**  
 This feature allows detecting/deleting orphan volumes that are not being used in any of the registered Kubernetes clusters on the vCenter. Read [here](docs/book/features/orphan_volumes.md) for more details about this feature.
 
-* **Orphan snapshots detection & deletion**
+* **Orphan snapshots detection & deletion**  
 This feature allows detecting/deleting orphan snapshots that are not being used in any of the registered Kubernetes clusters on the vCenter. Read [here](docs/book/features/orphan_snapshots.md) for more details about this feature.

--- a/client-sdk/go/client/api_cluster_record_keeping.go
+++ b/client-sdk/go/client/api_cluster_record_keeping.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2022 VMware, Inc.
+Copyright 2024 VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,12 +17,12 @@ package swagger
 
 import (
 	"context"
+	"github.com/antihax/optional"
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strings"
 	"os"
-	"github.com/antihax/optional"
+	"strings"
 )
 
 // Linger please
@@ -31,19 +31,21 @@ var (
 )
 
 type ClusterRecordKeepingApiService service
+
 /*
 ClusterRecordKeepingApiService Deregister a cluster with the CNS Manager.
 The API takes unique clusterID as input and de-registers the cluster from CNS Manager.
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param clusterId Refers to cluster-id available in decoded data field from vsphere-config-secret.
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param clusterId Refers to cluster-id available in decoded data field from vsphere-config-secret.
+
 @return DeregisterClusterResult
 */
 func (a *ClusterRecordKeepingApiService) Deregistercluster(ctx context.Context, clusterId string) (DeregisterClusterResult, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue DeregisterClusterResult
 	)
 
@@ -90,54 +92,56 @@ func (a *ClusterRecordKeepingApiService) Deregistercluster(ctx context.Context, 
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v DeregisterClusterResult
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 0 {
 			var v ModelError
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
+
 /*
 ClusterRecordKeepingApiService Get the list of registered k8s clusters from CNS manager inventory.
 CNS manager does a record keeping of all the clusters in a vCenter. The registered cluster config is  stored in the CNS manager inventory by using ClusterId as the key. The listregisteredclusters API will return the list of all the registered clusterIds as an array.
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+
 @return []string
 */
 func (a *ClusterRecordKeepingApiService) Listregisteredclusters(ctx context.Context) ([]string, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue []string
 	)
 
@@ -183,67 +187,68 @@ func (a *ClusterRecordKeepingApiService) Listregisteredclusters(ctx context.Cont
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []string
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 0 {
 			var v ModelError
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
+
 /*
 ClusterRecordKeepingApiService Register a Kubernetes cluster with CNS Manager.
-The API takes kubeconfig of a given cluster as an input. Make sure to copy the contents of the Cluster KubeConfig to a file. The kubeconfig is stored securely inside a k8s secret on the cluster where CNS manager is deployed.  The API additionally takes optional params like CSI driver clusterId or CSI driver namespace and config secret name  to read cluster-id from the CSI secret. 
+The API takes kubeconfig of a given cluster as an input. Make sure to copy the contents of the Cluster KubeConfig to a file. The kubeconfig is stored securely inside a k8s secret on the cluster where CNS manager is deployed.  The API additionally takes optional params like CSI driver clusterId or CSI driver namespace and config secret name  to read cluster-id from the CSI secret.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param optional nil or *ClusterRecordKeepingApiRegisterclusterOpts - Optional Parameters:
-     * @param "ClusterKubeConfigFile" (optional.*os.File) - 
+     * @param "ClusterKubeConfigFile" (optional.*os.File) -
      * @param "CsiDriverSecretName" (optional.String) -  (Optional) Refers to the name of the config secret of vsphere-csi-driver.
-     * @param "CsiDriverNamespace" (optional.String) -  (Optional) Refers to the namespace of vsphere-csi-driver.
-     * @param "ClusterId" (optional.String) -  (Optional) Cluster Id of the cluster to be registered with the CNS Manager.  This cluster Id needs to be the same that&#x27;s used in the vSphere CSI driver config of the Kubernetes cluster.  For vanilla Kubernetes distributions deployed using [VMware&#x27;s recommended way](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-BFF39F1D-F70A-4360-ABC9-85BDAFBE8864.html),  it will be present in the CSI secret and will be auto-computed from the provided kubeConfig.  For other Kubernetes distributions, please check their docs to determine how they&#x27;re configuring clusterId for the vSphere CSI driver in the Kubernetes cluster. 
+     * @param "CsiDriverSecretNamespace" (optional.String) -  (Optional) Refers to the namespace of the config secret of vsphere-csi-driver.
+     * @param "ClusterId" (optional.String) -  (Optional) Cluster Id of the cluster to be registered with the CNS Manager.  This cluster Id needs to be the same that&#x27;s used in the vSphere CSI driver config of the Kubernetes cluster.  For vanilla Kubernetes distributions deployed using [VMware&#x27;s recommended way](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-BFF39F1D-F70A-4360-ABC9-85BDAFBE8864.html),  it will be present in the CSI secret and will be auto-computed from the provided kubeConfig.  For other Kubernetes distributions, please check their docs to determine how they&#x27;re configuring clusterId for the vSphere CSI driver in the Kubernetes cluster.
 @return RegisterClusterResult
 */
 
 type ClusterRecordKeepingApiRegisterclusterOpts struct {
-    ClusterKubeConfigFile optional.Interface
-    CsiDriverSecretName optional.String
-    CsiDriverNamespace optional.String
-    ClusterId optional.String
+	ClusterKubeConfigFile    optional.Interface
+	CsiDriverSecretName      optional.String
+	CsiDriverSecretNamespace optional.String
+	ClusterId                optional.String
 }
 
 func (a *ClusterRecordKeepingApiService) Registercluster(ctx context.Context, localVarOptionals *ClusterRecordKeepingApiRegisterclusterOpts) (RegisterClusterResult, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue RegisterClusterResult
 	)
 
@@ -257,8 +262,8 @@ func (a *ClusterRecordKeepingApiService) Registercluster(ctx context.Context, lo
 	if localVarOptionals != nil && localVarOptionals.CsiDriverSecretName.IsSet() {
 		localVarQueryParams.Add("csiDriverSecretName", parameterToString(localVarOptionals.CsiDriverSecretName.Value(), ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.CsiDriverNamespace.IsSet() {
-		localVarQueryParams.Add("csiDriverNamespace", parameterToString(localVarOptionals.CsiDriverNamespace.Value(), ""))
+	if localVarOptionals != nil && localVarOptionals.CsiDriverSecretNamespace.IsSet() {
+		localVarQueryParams.Add("csiDriverSecretNamespace", parameterToString(localVarOptionals.CsiDriverSecretNamespace.Value(), ""))
 	}
 	if localVarOptionals != nil && localVarOptionals.ClusterId.IsSet() {
 		localVarQueryParams.Add("clusterId", parameterToString(localVarOptionals.ClusterId.Value(), ""))
@@ -280,12 +285,12 @@ func (a *ClusterRecordKeepingApiService) Registercluster(ctx context.Context, lo
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-    var localVarFile *os.File
+	var localVarFile *os.File
 	if localVarOptionals != nil && localVarOptionals.ClusterKubeConfigFile.IsSet() {
 		localVarFileOk := false
 		localVarFile, localVarFileOk = localVarOptionals.ClusterKubeConfigFile.Value().(*os.File)
 		if !localVarFileOk {
-				return localVarReturnValue, nil, reportError("clusterKubeConfigFile should be *os.File")
+			return localVarReturnValue, nil, reportError("clusterKubeConfigFile should be *os.File")
 		}
 	}
 	if localVarFile != nil {
@@ -312,36 +317,36 @@ func (a *ClusterRecordKeepingApiService) Registercluster(ctx context.Context, lo
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v RegisterClusterResult
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 0 {
 			var v ModelError
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client-sdk/go/client/api_orphan_volume.go
+++ b/client-sdk/go/client/api_orphan_volume.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2022 VMware, Inc.
+Copyright 2024 VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,11 +17,11 @@ package swagger
 
 import (
 	"context"
+	"github.com/antihax/optional"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"github.com/antihax/optional"
 )
 
 // Linger please
@@ -30,6 +30,7 @@ var (
 )
 
 type OrphanVolumeApiService service
+
 /*
 OrphanVolumeApiService Delete orphan volumes.
 Delete the orphan volumes for the given criteria.
@@ -42,16 +43,16 @@ Delete the orphan volumes for the given criteria.
 */
 
 type OrphanVolumeApiOrphanVolumeDeleteOpts struct {
-    Datacenter optional.String
-    Datastores optional.String
+	Datacenter optional.String
+	Datastores optional.String
 }
 
 func (a *OrphanVolumeApiService) OrphanVolumeDelete(ctx context.Context, deleteAttachedOrphans bool, localVarOptionals *OrphanVolumeApiOrphanVolumeDeleteOpts) (OrphanVolumeDeleteResult, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Delete")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue OrphanVolumeDeleteResult
 	)
 
@@ -104,48 +105,49 @@ func (a *OrphanVolumeApiService) OrphanVolumeDelete(ctx context.Context, deleteA
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v OrphanVolumeDeleteResult
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 0 {
 			var v ModelError
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
+
 /*
 OrphanVolumeApiService List all the orphan volumes.
-Returns a list of orphan volumes for the given input parameters, which could be attached or detached. Since the detection of orphan volumes is an expensive operation, the operation is performed asynchronously at regular intervals. This API returns the list of orphan volumes found in the last run of the operation.  If the request is successful, the response will contain the following: 1. &#x60;TotalOrphans&#x60; - The total number of orphan volumes found. 2. &#x60;OrphanVolumes&#x60; - The list of orphan volumes found. 3. &#x60;RetryAfterMinutes&#x60; - The time in minutes after which the next retry should be attempted to get the updated orphan volume list. 4. &#x60;TotalOrphansAttached&#x60; - The total number of orphan volumes found that are attached to a VM. 5. &#x60;TotalOrphansDetached&#x60; - The total number of orphan volumes found that are detached. 6. &#x60;Limit&#x60; - The maximum number of orphan volumes to be returned. 7. &#x60;NextOffset&#x60; - The offset of the next page if there are more orphan volumes to query. Orphan volumes are safe to delete since there is no PersistentVolume in the Kubernetes cluster referring to them. 
+Returns a list of orphan volumes for the given input parameters, which could be attached or detached. Since the detection of orphan volumes is an expensive operation, the operation is performed asynchronously at regular intervals. This API returns the list of orphan volumes found in the last run of the operation.  If the request is successful, the response will contain the following: 1. &#x60;TotalOrphans&#x60; - The total number of orphan volumes found. 2. &#x60;OrphanVolumes&#x60; - The list of orphan volumes found. 3. &#x60;RetryAfterMinutes&#x60; - The time in minutes after which the next retry should be attempted to get the updated orphan volume list. 4. &#x60;TotalOrphansAttached&#x60; - The total number of orphan volumes found that are attached to a VM. 5. &#x60;TotalOrphansDetached&#x60; - The total number of orphan volumes found that are detached. 6. &#x60;Limit&#x60; - The maximum number of orphan volumes to be returned. 7. &#x60;NextOffset&#x60; - The offset of the next page if there are more orphan volumes to query. Orphan volumes are safe to delete since there is no PersistentVolume in the Kubernetes cluster referring to them.
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param includeDetails Set to \&quot;true\&quot; to get a detailed dump of the orphan volume.
  * @param optional nil or *OrphanVolumeApiOrphanVolumeListOpts - Optional Parameters:
+     * @param "IncludeDetails" (optional.Bool) -  (Optional) Set to \&quot;true\&quot; to get a detailed dump of the orphan volume.
      * @param "Datacenter" (optional.String) -  (Optional) Datacenter name to narrow down the orphan volume search.
      * @param "Datastores" (optional.String) -  (Optional) List of comma-separated datastores. Specify only if the &#x60;datacenter&#x60; param is specified.
      * @param "Offset" (optional.Int32) -  (Optional) The offset indicates the starting point of the result set.
@@ -154,18 +156,19 @@ Returns a list of orphan volumes for the given input parameters, which could be 
 */
 
 type OrphanVolumeApiOrphanVolumeListOpts struct {
-    Datacenter optional.String
-    Datastores optional.String
-    Offset optional.Int32
-    Limit optional.Int32
+	IncludeDetails optional.Bool
+	Datacenter     optional.String
+	Datastores     optional.String
+	Offset         optional.Int32
+	Limit          optional.Int32
 }
 
-func (a *OrphanVolumeApiService) OrphanVolumeList(ctx context.Context, includeDetails bool, localVarOptionals *OrphanVolumeApiOrphanVolumeListOpts) (OrphanVolumeResult, *http.Response, error) {
+func (a *OrphanVolumeApiService) OrphanVolumeList(ctx context.Context, localVarOptionals *OrphanVolumeApiOrphanVolumeListOpts) (OrphanVolumeResult, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue OrphanVolumeResult
 	)
 
@@ -176,7 +179,9 @@ func (a *OrphanVolumeApiService) OrphanVolumeList(ctx context.Context, includeDe
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	localVarQueryParams.Add("includeDetails", parameterToString(includeDetails, ""))
+	if localVarOptionals != nil && localVarOptionals.IncludeDetails.IsSet() {
+		localVarQueryParams.Add("includeDetails", parameterToString(localVarOptionals.IncludeDetails.Value(), ""))
+	}
 	if localVarOptionals != nil && localVarOptionals.Datacenter.IsSet() {
 		localVarQueryParams.Add("datacenter", parameterToString(localVarOptionals.Datacenter.Value(), ""))
 	}
@@ -224,36 +229,36 @@ func (a *OrphanVolumeApiService) OrphanVolumeList(ctx context.Context, includeDe
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v OrphanVolumeResult
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 0 {
 			var v ModelError
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/client-sdk/go/client/model_orphan_volume_result.go
+++ b/client-sdk/go/client/model_orphan_volume_result.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2022 VMware, Inc.
+Copyright 2024 VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,15 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package swagger
 
 type OrphanVolumeResult struct {
-	// The total number of orphan volumes returned.
+	// The total number of orphan volumes detected in the vCenter for the input.
 	TotalOrphans int32 `json:"totalOrphans"`
 	// The total number of orphan volumes that are attached to a VM. This field is returned only if includeDetails is set to true.
 	TotalOrphansAttached int32 `json:"totalOrphansAttached,omitempty"`
-	// The total number of orphan volumes that are not attached to a VM. This field is set only if includeDetails is set to true.
+	// The total number of orphan volumes that are not attached to a VM. This field is returned only if includeDetails is set to true.
 	TotalOrphansDetached int32 `json:"totalOrphansDetached,omitempty"`
 	// Array of orphan volumes.
 	OrphanVolumes []OrphanVolume `json:"orphanVolumes"`

--- a/client-sdk/go/examples/basicauth_client.go
+++ b/client-sdk/go/examples/basicauth_client.go
@@ -113,11 +113,14 @@ func main() {
 	//======List orphan volumes======
 	includeDetails := true
 	opts := &apiclient.OrphanVolumeApiOrphanVolumeListOpts{
-		Datacenter: optional.NewString("VSAN-DC"),
-		Datastores: optional.NewString("vsanDatastore"),
+		Datacenter:     optional.NewString("VSAN-DC"),
+		Datastores:     optional.NewString("vsanDatastore"),
+		IncludeDetails: optional.NewBool(includeDetails),
+		Limit:          optional.NewInt32(50),
+		Offset:         optional.NewInt32(0),
 	}
 
-	res, resp, err := client.OrphanVolumeApi.OrphanVolumeList(ctx, includeDetails, opts)
+	res, resp, err := client.OrphanVolumeApi.OrphanVolumeList(ctx, opts)
 	if err != nil {
 		logger.Error(err, "failed to list orphan volumes")
 	}

--- a/deploy/basic-auth/deploy-template.yaml
+++ b/deploy/basic-auth/deploy-template.yaml
@@ -523,8 +523,8 @@ spec:
       serviceAccount: cns-manager
       containers:
         - name: nginx-proxy
-          # Same dockerhub copy hosted at nginx:1.23.0
-          image: projects.registry.vmware.com/cns_manager/nginx:1.23.0
+          # Same dockerhub copy hosted at nginxinc/nginx-unprivileged:1.25.3
+          image: projects.registry.vmware.com/cns_manager/nginx-unprivileged-amd64:1.25.3
           resources:
             requests:
               cpu: 100m
@@ -568,7 +568,7 @@ spec:
             - name: swagger-api
               mountPath: /api
         - name: cns-manager
-          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.3.0-rc.1
+          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.3.0-rc.3
           resources:
             requests:
               cpu: 500m
@@ -622,7 +622,7 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 80
+      targetPort: 8081
       nodePort: 30008
     - name: https
       port: 443

--- a/deploy/basic-auth/nginx.conf
+++ b/deploy/basic-auth/nginx.conf
@@ -2,9 +2,13 @@ events {
     worker_connections 1024;
 }
 
+# This is the location where Nginx will store the PID file.
+# The default location where Nginx stores the PID file is not accessible in certain flavors of K8s like OCP.
+pid /tmp/nginx.pid;
+
 http {
     server {
-        listen       80;
+        listen       8081;
         # Use below instead to configure an https server
         # listen       443 ssl;
 

--- a/deploy/oauth2/deploy-template.yaml
+++ b/deploy/oauth2/deploy-template.yaml
@@ -524,8 +524,8 @@ spec:
       serviceAccount: cns-manager
       containers:
         - name: nginx-proxy
-          # Same dockerhub copy hosted at nginx:1.23.0
-          image: projects.registry.vmware.com/cns_manager/nginx:1.23.0
+          # Same dockerhub copy hosted at nginxinc/nginx-unprivileged:1.25.3
+          image: projects.registry.vmware.com/cns_manager/nginx-unprivileged-amd64:1.25.3
           resources:
             requests:
               cpu: 100m
@@ -604,7 +604,7 @@ spec:
             - name: swagger-api
               mountPath: /api
         - name: cns-manager
-          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.3.0-rc.1
+          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.3.0-rc.3
           resources:
             requests:
               cpu: 500m
@@ -655,7 +655,7 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 80
+      targetPort: 8081
       nodePort: 30008
     - name: https
       port: 443

--- a/deploy/oauth2/nginx.conf
+++ b/deploy/oauth2/nginx.conf
@@ -2,9 +2,13 @@ events {
     worker_connections 1024;
 }
 
+# This is the location where Nginx will store the PID file.
+# The default location where Nginx stores the PID file is not accessible in certain flavors of K8s like OCP.
+pid /tmp/nginx.pid;
+
 http {
     server {
-        listen       80;
+        listen       8081;
         #Use below instead to configure an https server
         #listen       443 ssl;
         server_name  cnsmanager.cns.vmware.com;

--- a/deploy/swagger-template.yaml
+++ b/deploy/swagger-template.yaml
@@ -83,9 +83,9 @@ paths:
             type: string
             format: string
             default: vsphere-config-secret
-        - name: csiDriverNamespace
+        - name: csiDriverSecretNamespace
           in: query
-          description: (Optional) Refers to the namespace of vsphere-csi-driver.
+          description: (Optional) Refers to the namespace of the config secret of vsphere-csi-driver.
           style: form
           explode: true
           schema:
@@ -457,8 +457,7 @@ paths:
       parameters:
         - name: includeDetails
           in: query
-          description: Set to "true" to get a detailed dump of the orphan volume.
-          required: true
+          description: (Optional) Set to "true" to get a detailed dump of the orphan volume.
           style: form
           explode: true
           schema:
@@ -1294,7 +1293,7 @@ components:
       properties:
         totalOrphans:
           type: integer
-          description: The total number of orphan volumes returned.
+          description: The total number of orphan volumes detected in the vCenter for the input.
           example: 1
         totalOrphansAttached:
           type: integer
@@ -1304,7 +1303,7 @@ components:
         totalOrphansDetached:
           type: integer
           description: The total number of orphan volumes that are not attached to a VM.
-            This field is set only if includeDetails is set to true.
+            This field is returned only if includeDetails is set to true.
           example: 1
         orphanVolumes:
           type: array
@@ -1354,7 +1353,7 @@ components:
             details:
               attached: false
             capacityInMb: 100
-        totalOrphans: 3
+        totalOrphans: 30
         retryAfterMinutes: 10
         limit: 3
         nextOffset: 3

--- a/docs/book/features/orphan_snapshots.md
+++ b/docs/book/features/orphan_snapshots.md
@@ -1,13 +1,15 @@
 ## Orphan snapshots detection and clean-up
 From vSphere CSI driver's perspective, orphan snapshots are vSphere snapshots that were initiated through the vSphere CSI driver but do not have a corresponding VolumeSnapshotContent object in Kubernetes clusters on the vCenter.
-From Velero vSphere plugin's perspective, orphan snapshots are vSphere snapshots whose local deletion is failing after successful upload to the remote repository.
+
+From Velero vSphere plugin's perspective, orphan snapshots are vSphere snapshots whose local deletion is failing after successful upload to the remote repository.  
 Velero vSphere plugin performs following steps as part of backup:
 1. Take a snapshot of the volume.
 2. Upload the snapshot to a remote repository.
 3. Delete the snapshot.
+
 In these steps, deletion of local snapshot could fail, which leaves behind a snapshot. It can be considered as an orphan snapshot.
 
-Orphan snapshot detection algorithm considers snapshot prefix for listing a snapshot as an orphan snapshot. Snapshot prefix is the prefix used in the snapshot description (snapshot description can be fetched using the GET /volumes/{volumeId}/snapshots API or will be available in CNS spec).
+Orphan snapshot detection algorithm considers snapshot prefix for listing a snapshot as an orphan snapshot. Snapshot prefix is the prefix used in the snapshot description (snapshot description can be fetched using the GET /volumes/{volumeId}/snapshots API or will be available in CNS spec).  
 For example, vSphere CSI driver creates snapshots with default prefix of “snapshot”. So, all these snapshot’s description has prefix “snapshot”. Similarly, Velero vSphere plugin uses snapshot prefix as “AstrolabeSnapshot”. 
 CNS manager by default considers [“snapshot”, “AstrolableSnapshot”] as snapshot prefixes. These values are configurable using `snapshot-prefixes` parameter in the `cnsmanager-config` ConfigMap.
 
@@ -27,7 +29,7 @@ Some snapshots will not be considered during orphan snapshot detection/deletion.
 * Snapshots belonging to Kubernetes clusters which are not registered with CNS manager.
 
 ### A reminder to register all Kubernetes clusters!
-Before you start using orphan snapshot functionality, it's imperative that you register all the Kubernetes clusters in vCenter with CNS Manager, so that orphan snapshots are detected correctly. Any newly added Kubernetes cluster should also be immediately registered.
+Before you start using orphan snapshot functionality, it's imperative that you [register all the Kubernetes clusters](../../../README.md#register-kubernetes-clusters-before-you-start) in vCenter with CNS Manager, so that orphan snapshots are detected correctly. Any newly added Kubernetes cluster should also be immediately registered.
 
 ### APIs provided
 1. *GET /orphansnapshots*
@@ -36,42 +38,54 @@ This API is used to get list of orphan snapshots. It takes optional parameters, 
 - If datacenter is not specified, then it returns all orphan snapshots in the vCenter (all datastores on all datacenters ).
 - If only datacenter is specified, then it returns orphan snapshots in all datastores in the datacenter.
 - If both datacenter & list of datastores is specified, it returns orphan snapshots in specified datastores on the datacenter.
+
 This API also takes optional parameter snapshotPrefix, which indicates the prefix used in the snapshot description. So, this API returns orphan snapshots whose description’s prefix matches with the specified snapshot prefix. Default value of this parameter is “snapshot”.
 
 There could be hundreds of orphan snapshots, so this API supports pagination as well. It takes optional parameters limit (default value 50) and offset (default value 0). Limit specifies the maximum entries that should be displayed in single request, whereas offset specifies the starting point of the result set.
 
 Detection of orphan snapshots can be a time-consuming operation if there are large number of orphans. Hence it is performed asynchronously at regular intervals and the response is cached. This API returns list of orphan snapshots computed in the last run, along with the next operation interval (`RetryAfterMinutes`).
+
 **Note:** For newly deployed CNS manager application, when orphan snapshots are being computed in the background for the first time, the API may return no orphan snapshots. It should then be re-tried after `RetryAfterMinutes` to get orphan snapshots computed in the latest run.
 
 2. *DELETE /orphansnapshots*
-This API is used to delete orphan snapshots. It takes optional parameters, datacenter & list of datastores, and deletes orphan snapshots from them with the same logic explained above.
+
+This API is used to delete orphan snapshots. It takes optional parameters, datacenter & list of datastores, and deletes orphan snapshots from them with the same logic explained above.  
 This API also takes optional parameter snapshotPrefix, which indicates the prefix used in the snapshot description.
 
-Please note if there are large number of orphan snapshots in the system or if there's a slowness in vCenter networking/storage, the orphan snapshot deletion may take longer. That is why, orphan snapshot deletion operation is performed asynchronously.
+Please note if there are large number of orphan snapshots in the system or if there's a slowness in vCenter networking/storage, the orphan snapshot deletion may take longer. That is why, orphan snapshot deletion operation is performed asynchronously.  
 It creates a job to delete these orphan snapshots in the background and returns the job Id to user, the status of this job can be retrieved using `getjobstatus` API.
 
 
 Apart from APIs provided for detection/deletion of orphan snapshots, there are separate APIs to list/delete snapshots of a specific volume or to delete an individual snapshot.
 
 3. *GET /volumes/{volumeId}/snapshots*
-This API lists all the snapshots for a specific volume. It takes required parameters datacenter and datastore name to which volume and snapshots belong to.
+
+This API lists all the snapshots for a specific volume. It takes required parameters datacenter and datastore name to which volume and snapshots belong to.  
 This API also takes optional parameter snapshotPrefix which indicates the prefix used in snapshot description. If snapshot prefix is not specified, then it lists all snapshots of a volume. Otherwise it lists only those snapshots of volume whose description’s prefix matches with the specified snapshot prefix.
 
 4. *DELETE /volumes/{volumeId}/snapshots*
-This API deletes all snapshots of a specific volume. Similar to GET API, it takes required parameters datacenter and datastore and optional parameter snapshotPrefix.
+
+This API deletes all snapshots of a specific volume. Similar to GET API, it takes required parameters datacenter and datastore and optional parameter snapshotPrefix.  
 Deletion of all snapshots of a volume is performed asynchronously. It creates a job to delete these snapshots in the background and returns the job Id to user, the status of this job can be retrieved using `getjobstatus` API.
 
 5. *DELETE /volumes/{volumeId}/snapshots/{snapshotId}*
-This API deletes a specific snapshot belonging to a volume. It takes required parameters datacenter and datastore name to which volume and snapshot belongs to.
+
+This API deletes a specific snapshot belonging to a volume. It takes required parameters datacenter and datastore name to which volume and snapshot belongs to.  
 Deletion of a snapshot is performed asynchronously. It creates a job to delete this snapshot in the background and returns the job Id to user, the status of this job can be retrieved using `getjobstatus` API.
 
+### Checking status of the snapshot deletion job
 Two APIs are being offered to check the status of the snapshot deletion job (A job corresponds to a single invocation of the API, that can have multiple tasks corresponding to separate snapshot deletion).
-i. *GET /getjobstatus*
-This API returns the current status of the job. A job can be in one of the following status:
-    * Queued - Job has been created but hasn't started processing.
-    * Running - Job is currently executing.
-    * Success - Job has completed successfully with all tasks succeeding.
-    * Error - Job ran but some or all of its tasks failed.
-ii. *GET /waitforjob*
-This is a blocking API that waits for job to be successful or fail. Unlike getjobstatus API, this will wait for the job to finish before returning the job result response.
 
+1. *GET /getjobstatus*
+
+This API returns the current status of the job. A job can be in one of the following status:
+
+* Queued - Job has been created but hasn't started processing.
+* Running - Job is currently executing.
+* Success - Job has completed successfully with all tasks succeeding.
+* Error - Job ran but some or all of its tasks failed.
+
+2. *GET /waitforjob*
+
+This is a blocking API that waits for job to be successful or fail.  
+Unlike `getjobstatus` API, this will wait for the job to finish before returning the job result response.

--- a/docs/book/features/orphan_volumes.md
+++ b/docs/book/features/orphan_volumes.md
@@ -28,9 +28,13 @@ Before you start using orphan volume functionality, it's imperative that you [re
 1. *GET /orphanvolumes* 
 
 This API takes optional parameters, datacenter & list of datastores, and returns orphan volumes for them. 
-- If datacenter is not specified, then it returns all orphan volumes in the vCenter (all datastores on all datacenters ).
+- If datacenter is not specified, then it returns all orphan volumes in the vCenter (all datastores on all datacenters).
 - If only datacenter is specified, then it returns orphan volumes in all datastores in the datacenter.
 - If both datacenter & list of datastores is specified, it returns orphan volumes in specified datastores on the datacenter.
+
+This API also takes optional parameter includeDetails, it should be set to `true` to get a detailed dump of the orphan volumes.
+
+There could be hundreds of orphan volumes, so this API supports pagination as well. It takes optional parameters limit and offset. Limit specifies the maximum entries that should be displayed in single request, whereas offset specifies the starting point of the result set.
 
 Detection of orphan volumes can be a time-consuming operation if there are large number of orphans. Hence it is performed asynchronously at regular intervals and the response is cached. This API returns list of orphan volumes computed in the last run, along with the next operation interval(`RetryAfterMinutes`).  
 **Note:** For newly deployed CNS manager application when orphan volumes are being computed in the background for the first time, the API may return no orphan volumes. It should then be re-tried after `RetryAfterMinutes` to get orphan volumes computed in the latest run.


### PR DESCRIPTION
- Changes to update client-sdk files and doc as per recent changes made for orphan volumes feature
- There are minor formatting related changes in readme files

Testing done:
Deployed cns-manager using instructions provided on GitHub repo and verified that orphan snapshot related APIs are working.

```
# curl -X 'GET' 'http://<ip>:30008/1.0.0/orphansnapshots?limit=50' -H 'accept: application/json' -u "Admin:Admin" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   412  100   412    0     0  27466      0 --:--:-- --:--:-- --:--:-- 29428
{
  "totalOrphanSnapshots": 1,
  "limit": 50,
  "offset": 0,
  "orphanSnapshots": [
    {
      "volumeId": "f2e73a8b-91d2-4c86-96e3-7e136dde1d3f",
      "volumeSnapshotId": "677d55d3-b51f-4413-bb09-23bfa2b2c001",
      "datacenter": "VSAN-DC",
      "datastore": "vsanDatastore",
      "createTime": "2024-02-14 12:37:45.787118 +0000 UTC",
      "snapshotDescription": "snapshot-b8071245-ad49-499c-8b8d-83669318ae6c-f2e73a8b-91d2-4c86-96e3-7e136dde1d3f"
    }
  ],
  "retryAfterMinutes": 60
}


# curl -X 'GET' 'http://<ip>:30008/1.0.0/volumes/f2e73a8b-91d2-4c86-96e3-7e136dde1d3f/snapshots?datacenter=VSAN-DC&datastore=vsanDatastore' -H 'accept: application/json' -u "Admin:Admin" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   279  100   279    0     0    365      0 --:--:-- --:--:-- --:--:--   365
{
  "Snapshots": [
    {
      "snapshotId": "677d55d3-b51f-4413-bb09-23bfa2b2c001",
      "volumeId": "f2e73a8b-91d2-4c86-96e3-7e136dde1d3f",
      "createTime": "2024-02-14 12:37:45.787118 +0000 UTC",
      "snapshotDescription": "snapshot-b8071245-ad49-499c-8b8d-83669318ae6c-f2e73a8b-91d2-4c86-96e3-7e136dde1d3f"
    }
  ]
}


# curl -X 'DELETE' 'http://<ip>:30008/1.0.0/volumes/f2e73a8b-91d2-4c86-96e3-7e136dde1d3f/snapshots?datacenter=VSAN-DC&datastore=vsanDatastore' -H 'accept: application/json' -u "Admin:Admin" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    69  100    69    0     0    160      0 --:--:-- --:--:-- --:--:--   160
{
  "jobId": "snapshotdeletionjob-fe04d66f-cb38-11ee-884f-e2330787a620"
}


# curl -X 'GET' 'http://<ip>:30008/1.0.0/getjobstatus?jobId=snapshotdeletionjob-fe04d66f-cb38-11ee-884f-e2330787a620' -H 'accept: application/json' -u "Admin:Admin" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   674  100   674    0     0   5912      0 --:--:-- --:--:-- --:--:--  5860
{
  "jobId": "snapshotdeletionjob-fe04d66f-cb38-11ee-884f-e2330787a620",
  "phase": "Success",
  "jobParameters": {
    "fcdId": "f2e73a8b-91d2-4c86-96e3-7e136dde1d3f",
    "datacenter": "VSAN-DC",
    "datastores": [
      "vsanDatastore"
    ],
    "snapshotPrefix": "snapshot"
  },
  "jobStatus": {
    "totalSnapshotsPlannedForDeletion": 1,
    "totalSnapshotsSuccessfullyDeleted": 1,
    "startTime": "2024-02-14T13:00:13Z",
    "endTime": "2024-02-14T13:00:15Z",
    "snapshotDeletionTasks": [
      {
        "fcdId": "f2e73a8b-91d2-4c86-96e3-7e136dde1d3f",
        "snapshotId": "677d55d3-b51f-4413-bb09-23bfa2b2c001",
        "datacenter": "VSAN-DC",
        "datastore": "vsanDatastore",
        "phase": "Success",
        "taskStartTime": "2024-02-14T13:00:14Z",
        "taskEndTime": "2024-02-14T13:00:15Z",
        "error": {}
      }
    ]
  }
}
```