### PR TITLE
Update the images used in deployment templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+.idea
+
+### Go template
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+

--- a/deploy/basic-auth/deploy-template.yaml
+++ b/deploy/basic-auth/deploy-template.yaml
@@ -524,7 +524,7 @@ spec:
       containers:
         - name: nginx-proxy
           # Same dockerhub copy hosted at nginxinc/nginx-unprivileged:1.25.3
-          image: projects.registry.vmware.com/cns_manager/nginx-unprivileged-amd64:1.25.3
+          image: projects.packages.broadcom.com/cns_manager/nginx-unprivileged-amd64:1.25.3
           resources:
             requests:
               cpu: 100m
@@ -548,7 +548,7 @@ spec:
             #  readOnly: true
         - name: swagger-ui
           # Same dockerhub copy hosted at swaggerapi/swagger-ui:v4.12.0
-          image: projects.registry.vmware.com/cns_manager/swagger-ui:v4.12.0
+          image: projects.packages.broadcom.com/cns_manager/swagger-ui:v4.12.0
           env:
             - name: URL
               value: "./swagger.yaml"
@@ -568,7 +568,7 @@ spec:
             - name: swagger-api
               mountPath: /api
         - name: cns-manager
-          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.3.0
+          image: projects.packages.broadcom.com/cns_manager/cns-manager:r0.3.0
           resources:
             requests:
               cpu: 500m

--- a/deploy/oauth2/deploy-template.yaml
+++ b/deploy/oauth2/deploy-template.yaml
@@ -525,7 +525,7 @@ spec:
       containers:
         - name: nginx-proxy
           # Same dockerhub copy hosted at nginxinc/nginx-unprivileged:1.25.3
-          image: projects.registry.vmware.com/cns_manager/nginx-unprivileged-amd64:1.25.3
+          image: projects.packages.broadcom.com/cns_manager/nginx-unprivileged-amd64:1.25.3
           resources:
             requests:
               cpu: 100m
@@ -544,7 +544,7 @@ spec:
             #  readOnly: true
         - name: oauth2-proxy
           # Same copy as quay.io/oauth2-proxy/oauth2-proxy:v7.3.0-amd64
-          image: projects.registry.vmware.com/cns_manager/oauth2-proxy:v7.3.0-amd64
+          image: projects.packages.broadcom.com/cns_manager/oauth2-proxy:v7.3.0-amd64
           resources:
             requests:
               cpu: 100m
@@ -584,7 +584,7 @@ spec:
               name: web
         - name: swagger-ui
           # Same dockerhub copy hosted at swaggerapi/swagger-ui:v4.12.0
-          image: projects.registry.vmware.com/cns_manager/swagger-ui:v4.12.0
+          image: projects.packages.broadcom.com/cns_manager/swagger-ui:v4.12.0
           env:
             - name: URL
               value: "./swagger.yaml"
@@ -604,7 +604,7 @@ spec:
             - name: swagger-api
               mountPath: /api
         - name: cns-manager
-          image: projects.registry.vmware.com/cns_manager/cns-manager:r0.3.0
+          image: projects.packages.broadcom.com/cns_manager/cns-manager:r0.3.0
           resources:
             requests:
               cpu: 500m


### PR DESCRIPTION
**Summary:**

The registry in which the CNS Manager related images are present is moved from `projects.registry.vmware.com` to `projects.packages.broadcom.com`. This MR updates the `deploy-template.yaml` files to reflect the same

**Testing:**

Verified that the images exist in `projects.packages.broadcom.com` registry.